### PR TITLE
Update template 4cols.html

### DIFF
--- a/Resources/Private/Templates/Standard/4cols.html
+++ b/Resources/Private/Templates/Standard/4cols.html
@@ -7,9 +7,9 @@
         <div class="row {data.flexform_rowValign} {data.flexform_rowHalign} {data.flexform_rowCustom}">
             <f:for each="{children}" as="columns" key="rowNumber">
                 <f:if condition="{columns}">
-                    <f:render partial="BootstrapGridsColumn" arguments="{contentElements: columns.101, class: '{data.flexform_xsCol1} {data.flexform_smCol1} {data.flexform_mdCol1} {data.flexform_lgCol1} {data.flexform_xlCol1} {data.flexform_col31class}', options: options, settings: settings}"/>
-                    <f:render partial="BootstrapGridsColumn" arguments="{contentElements: columns.102, class: '{data.flexform_xsCol2} {data.flexform_smCol2} {data.flexform_mdCol2} {data.flexform_lgCol2} {data.flexform_xlCol2} {data.flexform_col32class}', options: options, settings: settings}"/>
-                    <f:render partial="BootstrapGridsColumn" arguments="{contentElements: columns.103, class: '{data.flexform_xsCol3} {data.flexform_smCol3} {data.flexform_mdCol3} {data.flexform_lgCol3} {data.flexform_xlCol3} {data.flexform_col33class}', options: options, settings: settings}"/>
+                    <f:render partial="BootstrapGridsColumn" arguments="{contentElements: columns.101, class: '{data.flexform_xsCol1} {data.flexform_smCol1} {data.flexform_mdCol1} {data.flexform_lgCol1} {data.flexform_xlCol1} {data.flexform_col41class}', options: options, settings: settings}"/>
+                    <f:render partial="BootstrapGridsColumn" arguments="{contentElements: columns.102, class: '{data.flexform_xsCol2} {data.flexform_smCol2} {data.flexform_mdCol2} {data.flexform_lgCol2} {data.flexform_xlCol2} {data.flexform_col42class}', options: options, settings: settings}"/>
+                    <f:render partial="BootstrapGridsColumn" arguments="{contentElements: columns.103, class: '{data.flexform_xsCol3} {data.flexform_smCol3} {data.flexform_mdCol3} {data.flexform_lgCol3} {data.flexform_xlCol3} {data.flexform_col43class}', options: options, settings: settings}"/>
                     <f:render partial="BootstrapGridsColumn" arguments="{contentElements: columns.104, class: '{data.flexform_xsCol4} {data.flexform_smCol4} {data.flexform_mdCol4} {data.flexform_lgCol4} {data.flexform_xlCol4} {data.flexform_col44class}', options: options, settings: settings}"/>
                 </f:if>
             </f:for>


### PR DESCRIPTION
When using the 4col template and setting additional, individual classes, only the 4th column gets this class in the frontend.
This is due to a typo (or copy error from the 3col template). changing "flexform_col**3**1class", "flexform_col**3**2class" and "flexform_col**3**3class" to "flexform_col**4**1class", "flexform_col**4**2class" and "flexform_col**4**3class" fixes this.

I would appreciate a merge into the really nice extension!