### PR TITLE
Fix Accordion active state

### DIFF
--- a/Resources/Private/Templates/Standard/Accordion.html
+++ b/Resources/Private/Templates/Standard/Accordion.html
@@ -11,7 +11,7 @@
                         <div class="card">
                             <div class="card-header" id="heading-c{child.data.uid}">
                                 <h5 class="mb-0">
-                                    <button class="btn btn-link {f:if(condition:iteration.index,then:'',else:'collapsed')}" data-toggle="collapse" data-parent="#accordion-{f:if(condition:data._LOCALIZED_UID, then:data._LOCALIZED_UID, else:data.uid)}" data-target="#collapse-{child.data.uid}" aria-expanded="false" aria-controls="collapse-{child.data.uid}">
+                                    <button class="btn btn-link {f:if(condition:iteration.index,then:'collapsed',else:'')}" data-toggle="collapse" data-parent="#accordion-{f:if(condition:data._LOCALIZED_UID, then:data._LOCALIZED_UID, else:data.uid)}" data-target="#collapse-{child.data.uid}" aria-expanded="false" aria-controls="collapse-{child.data.uid}">
                                         {child.data.header}
                                     </button>
                                 </h5>


### PR DESCRIPTION
On page load the header doesn't represent the same state as the content. This PR keeps the state in sync