### PR TITLE
[FEATURE] Add migration for Bootstrap 4 -> 5 hidden classes

### DIFF
--- a/Classes/Updates/RewriteHiddenClasses.php
+++ b/Classes/Updates/RewriteHiddenClasses.php
@@ -1,0 +1,100 @@
+<?php
+namespace Laxap\BootstrapGrids\Updates;
+
+/*
+ *
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ *
+ */
+
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Attribute\UpgradeWizard;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+
+#[UpgradeWizard('rewriteHiddenClasses')]
+class RewriteHiddenClasses implements UpgradeWizardInterface
+{
+    public function getTitle(): string
+    {
+        return 'Rewrite "hidden-*" classes in FlexForm source';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Rewrites FlexForm data to make any "hidden-xs" through "hidden-xl" variables into new syntax';
+    }
+
+    public function executeUpdate(): bool
+    {
+        $connection = $this->createConnection('tt_content');
+        $querBuilder = $connection->createQueryBuilder();
+        $result = $querBuilder->select('uid', 'pi_flexform')->from('tt_content')->where(
+            $querBuilder->expr()->eq('CType', $querBuilder->createNamedParameter('gridelements_pi1')),
+            $querBuilder->expr()->like(
+                'pi_flexform',
+                $querBuilder->createNamedParameter('%<value index="vDEF">hidden-%')
+            )
+        )->executeQuery();
+
+        while ($row = $result->fetchAssociative()) {
+            $source = str_replace(
+                [
+                    '<value index="vDEF">hidden-xs</value>',
+                    '<value index="vDEF">hidden-sm</value>',
+                    '<value index="vDEF">hidden-md</value>',
+                    '<value index="vDEF">hidden-lg</value>',
+                    '<value index="vDEF">hidden-xl</value>',
+                    '<value index="vDEF">hidden-xxl</value>',
+                ],
+                [
+                    '<value index="vDEF">d-none</value>',
+                    '<value index="vDEF">d-sm-none</value>',
+                    '<value index="vDEF">d-md-none</value>',
+                    '<value index="vDEF">d-lg-none</value>',
+                    '<value index="vDEF">d-xl-none</value>',
+                    '<value index="vDEF">d-xxl-none</value>',
+                ],
+                $row['pi_flexform']
+            );
+
+            $connection->update('tt_content', ['pi_flexform' => $source], ['uid' => $row['uid']]);
+        }
+
+        return true;
+    }
+
+    public function updateNecessary(): bool
+    {
+        $connection = $this->createConnection('tt_content');
+        $querBuilder = $connection->createQueryBuilder();
+        $count = $querBuilder->select('*')->from('tt_content')->where(
+            $querBuilder->expr()->eq('CType', $querBuilder->createNamedParameter('gridelements_pi1')),
+            $querBuilder->expr()->like(
+                'pi_flexform',
+                $querBuilder->createNamedParameter('%<value index="vDEF">hidden-%')
+            )
+        )->executeQuery()->rowCount();
+        return $count > 0;
+    }
+
+    public function getPrerequisites(): array
+    {
+        return [];
+    }
+
+    private function createConnection(string $table): Connection
+    {
+        /** @var  $connectionPool */
+        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
+        return $connectionPool->getConnectionForTable($table);
+    }
+}


### PR DESCRIPTION
Adds a migration that converts `hidden-*` to `d-*-none` classes in FlexForm data in DB.

Note that this only converts the classes 1:1 which means it functions as a "hide column on this size and any larger size". In order to make it a "hide column only on this size", a template change is required which for every breakpoints adds an additional class if `d-*-none` is designated, to make the column visible again on the next breakpoint.

To _hide_ a column on larger sizes you just add the `d-*-none` class on the breakpoint where hiding starts and the column will be hidden on that size and any larger size.

Inversely, to make the functionality "show only on this and larger size" you would have set `d-*-none` on the smaller sizes and `d-*-block` on larger sizes. This however is not supported by the templates that ship with the extension.

For example, `d-md-none` would need to become `d-md-none d-lg-block`. Unfortunately it doesn't seem like it's possible to force Bootstrap to use whichever display type the HTML element type would naturally have, so this would have to be a decision on a template-by-template basis. If any element (column) is NOT a "block" display type, then the needed display type would have to be specified instead of "block".

**Note that this PR requires the same Services.yaml change that is in https://github.com/RozbehSharahi/bootstrap_grids/pull/75.**