### PR TITLE
Fix: Not set gets lost after second save

### DIFF
--- a/Classes/Backend/ColumnOptionsProvider.php
+++ b/Classes/Backend/ColumnOptionsProvider.php
@@ -45,7 +45,7 @@ class ColumnOptionsProvider
                     ['91.7%', 'col-11'],
                     ['100%', 'col-12'],
                     [$this->getLangKey('grid.label.moreOptions'), '--div--'],
-                    [$this->getLangKey('grid.label.notset'), ' '],
+                    [$this->getLangKey('grid.label.notset'), '---'],
                     [$this->getLangKey('grid.label.variableWidth'), 'col-auto']
                 ];
                 break;


### PR DESCRIPTION
Well TYPO3 seems to handle an empty string as not set, leading to tca to auto-select the first select option after save.

As a little hack I simple defined '---' as not-set value. Which ofc causes a class '---' in frontend, but i think for now it will not do harm anywhere as it is very unlikely to be styled by anyone that uses this extension. I might be wrong in the future and recovery is definitly possible if someone steps on this as a bug.