### PR TITLE
Improvements to locallang_db.xlf and de.locallang_db.xlf

### DIFF
--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -1,104 +1,106 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <xliff version="1.0">
-    <file source-language="en" datatype="plaintext" original="messages" date="2015-02-07T00:02:05Z"
-          product-name="bootstrap_grids">
+    <file source-language="en" datatype="plaintext" original="messages" date="2015-02-07T00:02:05Z" product-name="bootstrap_grids">
         <header/>
         <body>
             <trans-unit id="2cols.title" xml:space="preserve">
-                <source>2 columns</source>
+                <source>2 Columns</source>
                 <target>2 Spalten</target>
             </trans-unit>
             <trans-unit id="2cols.description" xml:space="preserve">
-                <source>Inserts a 2-columns grid for content. The width of each column may be set for different screen sizes.</source>
-                <target>Fügt ein 2-Spalten Grid für Inhalt ein. Die Breite einer jeder Spalte kann für unterschiedliche Bildschirmgrößen gesetzt werden.</target>
+                <source>Inserts a 2-column grid for content. The width of each column may be set for different screen sizes.</source>
+                <target>Fügt ein 2-Spalten-Grid für Inhalte ein. Die Breite jeder Spalte kann für unterschiedliche Bildschirmgrößen gesetzt werden.</target>
             </trans-unit>
             <trans-unit id="3cols.title" xml:space="preserve">
-                <source>3 columns</source>
+                <source>3 Columns</source>
                 <target>3 Spalten</target>
             </trans-unit>
             <trans-unit id="3cols.description" xml:space="preserve">
-                <source>Inserts a 3-columns grid for content.</source>
-                <target>Fügt ein 3-Spalten Grid für Inhalt ein. </target>
+                <source>Inserts a 3-column grid for content.</source>
+                <target>Fügt ein 3-Spalten-Grid für Inhalte ein. </target>
             </trans-unit>
             <trans-unit id="4cols.title" xml:space="preserve">
-                <source>4 columns</source>
+                <source>4 Columns</source>
                 <target>4 Spalten</target>
             </trans-unit>
             <trans-unit id="4cols.description" xml:space="preserve">
-                <source>Inserts a 4-columns grid for content.</source>
-                <target>Fügt ein 4-Spalten Grid für Inhalt ein. </target>
+                <source>Inserts a 4-column grid for content.</source>
+                <target>Fügt ein 4-Spalten-Grid für Inhalte ein.</target>
             </trans-unit>
             <trans-unit id="tabsSimple.title" xml:space="preserve">
-                <source>Tabs from content</source>
+                <source>Tabs From Content</source>
                 <target>Tabs aus dem Inhalt</target>
             </trans-unit>
             <trans-unit id="tabsSimple.description" xml:space="preserve">
                 <source>Each content element within the grid represents a tab. The title fields are used as tab titles.</source>
-                <target>Jedes Inhaltelement innerhalb der Grids repräsentiert einen Tab. Die Titel-Felder werden als Tab-Titel verwendet.</target>
+                <target>Jedes Inhaltselement innerhalb des Grids repräsentiert einen Tab. Die Titelfelder werden als Tab-Titel verwendet.</target>
             </trans-unit>
             <trans-unit id="tabs4.title" xml:space="preserve">
                 <source>Tabs (4)</source>
                 <target>Tabs (4)</target>
             </trans-unit>
             <trans-unit id="tabs4.description" xml:space="preserve">
-                <source>For multiple content elements in one tab. 4 or less tabs.</source>
-                <target>Für mehrfache Inhaltselemente in einem Tab. 4 oder weniger Tabs.</target>
+                <source>For multiple content elements in one tab. 4 or fewer tabs.</source>
+                <target>Für mehrere Inhaltselemente in einem Tab. 4 oder weniger Tabs.</target>
             </trans-unit>
             <trans-unit id="tabs6.title" xml:space="preserve">
                 <source>Tabs (6)</source>
                 <target>Tabs (6)</target>
             </trans-unit>
             <trans-unit id="tabs6.description" xml:space="preserve">
-                <source>For multiple content elements in one tab. 6 or less tabs.</source>
-                <target>Für mehrfache Inhaltselemente in einem Tab. 6 oder weniger Tabs.</target>
+                <source>For multiple content elements in one tab. 6 or fewer tabs.</source>
+                <target>Für mehrere Inhaltselemente in einem Tab. 6 oder weniger Tabs.</target>
             </trans-unit>
             <trans-unit id="accordion.title" xml:space="preserve">
-                <source>Accordion from content</source>
-                <target>Acordion aus dem Inhalt</target>
+                <source>Accordion From Content</source>
+                <target>Akkordeon aus dem Inhalt</target>
             </trans-unit>
             <trans-unit id="accordion.description" xml:space="preserve">
                 <source>Each content element within the grid represents an accordion element. The title fields are used as accordion bar titles.</source>
-                <target>Jedes Inhaltselement innerhalb des Grids stellt eine Accordion-Element dar. Die Titel-Felder werden als Accordion Leisten-Titel verwendet.</target>
+                <target>Jedes Inhaltselement innerhalb des Grids stellt ein Akkordeon-Element dar. Die Titelfelder werden als Akkordeon-Kopfzeilen verwendet.</target>
             </trans-unit>
+
             <trans-unit id="accordion.firstOpened" xml:space="preserve">
                 <source>First item open by default</source>
                 <target>Standardmäßig das erste Element geöffnet</target>
             </trans-unit>
             <trans-unit id="accordion.allClosed" xml:space="preserve">
-                <source>Display all closed by default</source>
-                <target>Alle geschlossen zeigen</target>
+                <source>Show all closed by default</source>
+                <target>Alle Elemente sind standardmäßig geschlossen</target>
             </trans-unit>
+
             <trans-unit id="xSimpleRow.title" xml:space="preserve">
                 <source>Row</source>
                 <target>Zeile</target>
             </trans-unit>
             <trans-unit id="xSimpleRow.description" xml:space="preserve">
                 <source>For use with responsive column width.</source>
-                <target>Verwenden mit Repsonsive Spalte.</target>
+                <target>Zur Verwendung mit responsiver Spaltenbreite.</target>
             </trans-unit>
+
             <trans-unit id="celayout.leftColumn" xml:space="preserve">
-                <source>Left column</source>
+                <source>Left Column</source>
                 <target>Linke Spalte</target>
             </trans-unit>
             <trans-unit id="celayout.rightColumn" xml:space="preserve">
-                <source>Right column</source>
+                <source>Right Column</source>
                 <target>Rechte Spalte</target>
             </trans-unit>
             <trans-unit id="celayout.centerColumn" xml:space="preserve">
-                <source>Center column</source>
+                <source>Center Column</source>
                 <target>Mittel Spalte</target>
             </trans-unit>
             <trans-unit id="celayout.column2" xml:space="preserve">
-                <source>2nd column</source>
-                <target>2. Spalte</target>
+                <source>Column 2</source>
+                <target>Spalte 2</target>
             </trans-unit>
             <trans-unit id="celayout.column3" xml:space="preserve">
-                <source>3rd column</source>
-                <target>3. Spalte</target>
+                <source>Column 3</source>
+                <target>Spalte 3</target>
             </trans-unit>
             <trans-unit id="celayout.tabElements" xml:space="preserve">
-                <source>Tab elements</source>
-                <target>Tab Element</target>
+                <source>Tab Elements</source>
+                <target>Tab-Elemente</target>
             </trans-unit>
             <trans-unit id="celayout.tab1" xml:space="preserve">
                 <source>Tab 1</source>
@@ -125,23 +127,24 @@
                 <target>Tab 6</target>
             </trans-unit>
             <trans-unit id="celayout.accordionElements" xml:space="preserve">
-                <source>Accordion elements</source>
-                <target>Accordion Elemente</target>
+                <source>Accordion Elements</source>
+                <target>Akkordeon-Elemente</target>
             </trans-unit>
             <trans-unit id="celayout.columnElements" xml:space="preserve">
-                <source>Column elements</source>
-                <target>Spalten Elemente</target>
+                <source>Column Elements</source>
+                <target>Spaltenelemente</target>
             </trans-unit>
+
             <trans-unit id="grid.sheet.mediumDevices" xml:space="preserve">
                 <source>Desktop</source>
                 <target>Desktop</target>
             </trans-unit>
             <trans-unit id="grid.sheet.smallDevices" xml:space="preserve">
-                <source>Small devices</source>
+                <source>Small Devices</source>
                 <target>Kleine Geräte</target>
             </trans-unit>
             <trans-unit id="grid.sheet.extraSmallDevices" xml:space="preserve">
-                <source>Extra small</source>
+                <source>Extra Small</source>
                 <target>Extra klein</target>
             </trans-unit>
             <trans-unit id="grid.sheet.largeDevices" xml:space="preserve">
@@ -150,10 +153,10 @@
             </trans-unit>
             <trans-unit id="grid.sheet.extraLargeDevices" xml:space="preserve">
                 <source>Extra Large</source>
-                <target>Extra groß</target>
+                <target>Extra Groß</target>
             </trans-unit>
             <trans-unit id="grid.sheet.customClasses" xml:space="preserve">
-                <source>Custom classes</source>
+                <source>Custom Classes</source>
                 <target>Custom Klassen</target>
             </trans-unit>
             <trans-unit id="grid.label.col1" xml:space="preserve">
@@ -173,15 +176,15 @@
                 <target>Spalte 4</target>
             </trans-unit>
             <trans-unit id="grid.label.moreWidth" xml:space="preserve">
-                <source>More width</source>
-                <target>Breite erhöhen</target>
+                <source>More Width</source>
+                <target>Breite Erhöhen</target>
             </trans-unit>
             <trans-unit id="grid.label.notset" xml:space="preserve">
-                <source>not set</source>
-                <target>nicht gesetzt</target>
+                <source>Not Set</source>
+                <target>Nicht Gesetzt</target>
             </trans-unit>
             <trans-unit id="grid.label.moreOptions" xml:space="preserve">
-                <source>More options</source>
+                <source>More Options</source>
                 <target>Mehr Optionen</target>
             </trans-unit>
             <trans-unit id="grid.label.special" xml:space="preserve">
@@ -189,25 +192,26 @@
                 <target>Spezial</target>
             </trans-unit>
             <trans-unit id="grid.label.hidden" xml:space="preserve">
-                <source>hidden</source>
-                <target>versteckt</target>
+                <source>Hidden</source>
+                <target>Versteckt</target>
             </trans-unit>
             <trans-unit id="grid.label.visible" xml:space="preserve">
-                <source>visible</source>
-                <target>sichtbar</target>
+                <source>Visible</source>
+                <target>Sichtbar</target>
             </trans-unit>
             <trans-unit id="grid.label.autoLayout" xml:space="preserve">
-                <source>Auto layout (col)</source>
+                <source>Auto Layout (Columns)</source>
                 <target>Auto Layout (Spalten)</target>
             </trans-unit>
             <trans-unit id="grid.label.variableWidth" xml:space="preserve">
-                <source>Variable width</source>
+                <source>Variable Width</source>
                 <target>Variable Breite</target>
             </trans-unit>
             <trans-unit id="grid.label.rowCustom" xml:space="preserve">
-                <source>Custom row classes</source>
-                <target>Custom Spalten Klassen</target>
+                <source>Custom Row Classes</source>
+                <target>Benutzerdefinierte Zeilenklassen</target>
             </trans-unit>
+
             <trans-unit id="grid.sheet.animation" xml:space="preserve">
                 <source>Animation</source>
                 <target>Animation</target>
@@ -220,6 +224,7 @@
                 <source>Options</source>
                 <target>Optionen</target>
             </trans-unit>
+
             <trans-unit id="grid.sheet.layout" xml:space="preserve">
                 <source>Layout</source>
                 <target>Layout</target>
@@ -254,7 +259,7 @@
             </trans-unit>
             <trans-unit id="grid.label.tabTitle4" xml:space="preserve">
                 <source>Title 4</source>
-                <target>Titel 3</target>
+                <target>Titel 4</target>
             </trans-unit>
             <trans-unit id="grid.label.tabTitle5" xml:space="preserve">
                 <source>Title 5</source>
@@ -272,13 +277,14 @@
                 <source>Title 8</source>
                 <target>Titel 8</target>
             </trans-unit>
+
             <trans-unit id="grid.sheet.rowClasses" xml:space="preserve">
-                <source>Row classes</source>
-                <target>Spalten Klassen</target>
+                <source>Row Classes</source>
+                <target>Zeilenklassen</target>
             </trans-unit>
             <trans-unit id="grid.label.rowValign" xml:space="preserve">
-                <source>Vertical alignment</source>
-                <target>Vertikale Auirichtung</target>
+                <source>Vertical Alignment</source>
+                <target>Vertikale Ausrichtung</target>
             </trans-unit>
             <trans-unit id="grid.rowValign.alignItemsStart" xml:space="preserve">
                 <source>Start</source>
@@ -293,7 +299,7 @@
                 <target>Ende</target>
             </trans-unit>
             <trans-unit id="grid.label.rowHalign" xml:space="preserve">
-                <source>Horiztontal alignment</source>
+                <source>Horizontal Alignment</source>
                 <target>Horizontale Ausrichtung</target>
             </trans-unit>
             <trans-unit id="grid.rowHalign.justifyContentStart" xml:space="preserve">
@@ -314,20 +320,22 @@
             </trans-unit>
             <trans-unit id="grid.rowHalign.justifyContentBetween" xml:space="preserve">
                 <source>Between</source>
-                <target>Dazwischen</target>
+                <target>Zwischen</target>
             </trans-unit>
+
             <trans-unit id="grid.label.none" xml:space="preserve">
-                <source>none</source>
-                <target>kein</target>
+                <source>None</source>
+                <target>Kein</target>
             </trans-unit>
             <trans-unit id="grid.label.yes" xml:space="preserve">
-                <source>yes</source>
-                <target>ja</target>
+                <source>Yes</source>
+                <target>Ja</target>
             </trans-unit>
             <trans-unit id="grid.label.no" xml:space="preserve">
-                <source>no</source>
-                <target>nein</target>
+                <source>No</source>
+                <target>Nein</target>
             </trans-unit>
+
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -41,7 +41,7 @@
             </trans-unit>
             <trans-unit id="tabs4.description" xml:space="preserve">
                 <source>For multiple content elements in one tab. 4 or fewer tabs.</source>
-                <target>Für mehrere Inhaltselemente in einem Tab. 4 oder weniger Tabs.</target>
+                <target>Für mehrere Inhaltselemente in einem Tab. Bis zu 4 Tabs.</target>
             </trans-unit>
             <trans-unit id="tabs6.title" xml:space="preserve">
                 <source>Tabs (6)</source>
@@ -49,7 +49,7 @@
             </trans-unit>
             <trans-unit id="tabs6.description" xml:space="preserve">
                 <source>For multiple content elements in one tab. 6 or fewer tabs.</source>
-                <target>Für mehrere Inhaltselemente in einem Tab. 6 oder weniger Tabs.</target>
+                <target>Für mehrere Inhaltselemente in einem Tab. Bis zu 6 Tabs.</target>
             </trans-unit>
             <trans-unit id="accordion.title" xml:space="preserve">
                 <source>Accordion From Content</source>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -4,256 +4,256 @@
         <header/>
         <body>
             <trans-unit id="2cols.title" xml:space="preserve">
-				<source>2 columns</source>
-			</trans-unit>
+                <source>2 Columns</source>
+            </trans-unit>
             <trans-unit id="2cols.description" xml:space="preserve">
-				<source>Inserts a 2-columns grid for content. The width of each column may be set for different screen sizes.</source>
-			</trans-unit>
+                <source>Inserts a 2-column grid for content. The width of each column may be set for different screen sizes.</source>
+            </trans-unit>
             <trans-unit id="3cols.title" xml:space="preserve">
-				<source>3 columns</source>
-			</trans-unit>
+                <source>3 Columns</source>
+            </trans-unit>
             <trans-unit id="3cols.description" xml:space="preserve">
-				<source>Inserts a 3-columns grid for content.</source>
-			</trans-unit>
+                <source>Inserts a 3-column grid for content.</source>
+            </trans-unit>
             <trans-unit id="4cols.title" xml:space="preserve">
-				<source>4 columns</source>
-			</trans-unit>
+                <source>4 Columns</source>
+            </trans-unit>
             <trans-unit id="4cols.description" xml:space="preserve">
-				<source>Inserts a 4-columns grid for content.</source>
-			</trans-unit>
+                <source>Inserts a 4-column grid for content.</source>
+            </trans-unit>
             <trans-unit id="tabsSimple.title" xml:space="preserve">
-				<source>Tabs from content</source>
-			</trans-unit>
+                <source>Tabs From Content</source>
+            </trans-unit>
             <trans-unit id="tabsSimple.description" xml:space="preserve">
-				<source>Each content element within the grid represents a tab. The title fields are used as tab titles.</source>
-			</trans-unit>
+                <source>Each content element within the grid represents a tab. The title fields are used as tab titles.</source>
+            </trans-unit>
             <trans-unit id="tabs4.title" xml:space="preserve">
-				<source>Tabs (4)</source>
-			</trans-unit>
+                <source>Tabs (4)</source>
+            </trans-unit>
             <trans-unit id="tabs4.description" xml:space="preserve">
-				<source>For multiple content elements in one tab. 4 or less tabs.</source>
-			</trans-unit>
+                <source>For multiple content elements in one tab. 4 or fewer tabs.</source>
+            </trans-unit>
             <trans-unit id="tabs6.title" xml:space="preserve">
-				<source>Tabs (6)</source>
-			</trans-unit>
+                <source>Tabs (6)</source>
+            </trans-unit>
             <trans-unit id="tabs6.description" xml:space="preserve">
-				<source>For multiple content elements in one tab. 6 or less tabs.</source>
-			</trans-unit>
+                <source>For multiple content elements in one tab. 6 or fewer tabs.</source>
+            </trans-unit>
             <trans-unit id="accordion.title" xml:space="preserve">
-				<source>Accordion from content</source>
-			</trans-unit>
+                <source>Accordion From Content</source>
+            </trans-unit>
             <trans-unit id="accordion.description" xml:space="preserve">
-				<source>Each content element within the grid represents an accordion element. The title fields are used as accordion bar titles.</source>
-			</trans-unit>
+                <source>Each content element within the grid represents an accordion element. The title fields are used as accordion bar titles.</source>
+            </trans-unit>
 
-			<trans-unit id="accordion.firstOpened" xml:space="preserve">
+            <trans-unit id="accordion.firstOpened" xml:space="preserve">
                 <source>First item open by default</source>
             </trans-unit>
             <trans-unit id="accordion.allClosed" xml:space="preserve">
-                <source>Display all closed by default</source>
+                <source>Show all closed by default</source>
             </trans-unit>
 
             <trans-unit id="xSimpleRow.title" xml:space="preserve">
-				<source>Row</source>
-			</trans-unit>
+                <source>Row</source>
+            </trans-unit>
             <trans-unit id="xSimpleRow.description" xml:space="preserve">
-				<source>For use with responsive column width.</source>
-			</trans-unit>
+                <source>For use with responsive column width.</source>
+            </trans-unit>
 
             <trans-unit id="celayout.leftColumn" xml:space="preserve">
-				<source>Left column</source>
-			</trans-unit>
+                <source>Left Column</source>
+            </trans-unit>
             <trans-unit id="celayout.rightColumn" xml:space="preserve">
-				<source>Right column</source>
-			</trans-unit>
+                <source>Right Column</source>
+            </trans-unit>
             <trans-unit id="celayout.centerColumn" xml:space="preserve">
-				<source>Center column</source>
-			</trans-unit>
+                <source>Center Column</source>
+            </trans-unit>
             <trans-unit id="celayout.column2" xml:space="preserve">
-				<source>2nd column</source>
+                <source>Column 2</source>
             </trans-unit>
             <trans-unit id="celayout.column3" xml:space="preserve">
-				<source>3rd column</source>
+                <source>Column 3</source>
             </trans-unit>
             <trans-unit id="celayout.tabElements" xml:space="preserve">
-				<source>Tab elements</source>
+                <source>Tab Elements</source>
             </trans-unit>
             <trans-unit id="celayout.tab1" xml:space="preserve">
-				<source>Tab 1</source>
+                <source>Tab 1</source>
             </trans-unit>
             <trans-unit id="celayout.tab2" xml:space="preserve">
-				<source>Tab 2</source>
+                <source>Tab 2</source>
             </trans-unit>
             <trans-unit id="celayout.tab3" xml:space="preserve">
-				<source>Tab 3</source>
+                <source>Tab 3</source>
             </trans-unit>
             <trans-unit id="celayout.tab4" xml:space="preserve">
-				<source>Tab 4</source>
+                <source>Tab 4</source>
             </trans-unit>
             <trans-unit id="celayout.tab5" xml:space="preserve">
-				<source>Tab 5</source>
+                <source>Tab 5</source>
             </trans-unit>
             <trans-unit id="celayout.tab6" xml:space="preserve">
-				<source>Tab 6</source>
+                <source>Tab 6</source>
             </trans-unit>
             <trans-unit id="celayout.accordionElements" xml:space="preserve">
-				<source>Accordion elements</source>
+                <source>Accordion Elements</source>
             </trans-unit>
             <trans-unit id="celayout.columnElements" xml:space="preserve">
-				<source>Column elements</source>
+                <source>Column Elements</source>
             </trans-unit>
 
             <trans-unit id="grid.sheet.mediumDevices" xml:space="preserve">
-				<source>Desktop</source>
-			</trans-unit>
+                <source>Desktop</source>
+            </trans-unit>
             <trans-unit id="grid.sheet.smallDevices" xml:space="preserve">
-				<source>Small devices</source>
-			</trans-unit>
+                <source>Small Devices</source>
+            </trans-unit>
             <trans-unit id="grid.sheet.extraSmallDevices" xml:space="preserve">
-				<source>Extra small</source>
-			</trans-unit>
+                <source>Extra Small</source>
+            </trans-unit>
             <trans-unit id="grid.sheet.largeDevices" xml:space="preserve">
-				<source>Large</source>
-			</trans-unit>
+                <source>Large</source>
+            </trans-unit>
             <trans-unit id="grid.sheet.extraLargeDevices" xml:space="preserve">
-				<source>Extra Large</source>
-			</trans-unit>
+                <source>Extra Large</source>
+            </trans-unit>
             <trans-unit id="grid.sheet.customClasses" xml:space="preserve">
-				<source>Custom classes</source>
-			</trans-unit>
+                <source>Custom Classes</source>
+            </trans-unit>
             <trans-unit id="grid.label.col1" xml:space="preserve">
-				<source>Column 1</source>
-			</trans-unit>
+                <source>Column 1</source>
+            </trans-unit>
             <trans-unit id="grid.label.col2" xml:space="preserve">
-				<source>Column 2</source>
-			</trans-unit>
+                <source>Column 2</source>
+            </trans-unit>
             <trans-unit id="grid.label.col3" xml:space="preserve">
-				<source>Column 3</source>
-			</trans-unit>
+                <source>Column 3</source>
+            </trans-unit>
             <trans-unit id="grid.label.col4" xml:space="preserve">
-				<source>Column 4</source>
-			</trans-unit>
+                <source>Column 4</source>
+            </trans-unit>
             <trans-unit id="grid.label.moreWidth" xml:space="preserve">
-				<source>More width</source>
-			</trans-unit>
+                <source>More Width</source>
+            </trans-unit>
             <trans-unit id="grid.label.notset" xml:space="preserve">
-				<source>not set</source>
-			</trans-unit>
+                <source>Not Set</source>
+            </trans-unit>
             <trans-unit id="grid.label.moreOptions" xml:space="preserve">
-				<source>More options</source>
-			</trans-unit>
+                <source>More Options</source>
+            </trans-unit>
             <trans-unit id="grid.label.special" xml:space="preserve">
-				<source>Special</source>
-			</trans-unit>
+                <source>Special</source>
+            </trans-unit>
             <trans-unit id="grid.label.hidden" xml:space="preserve">
-				<source>hidden</source>
-			</trans-unit>
+                <source>Hidden</source>
+            </trans-unit>
             <trans-unit id="grid.label.visible" xml:space="preserve">
-				<source>visible</source>
-			</trans-unit>
+                <source>Visible</source>
+            </trans-unit>
             <trans-unit id="grid.label.autoLayout" xml:space="preserve">
-				<source>Auto layout (col)</source>
-			</trans-unit>
+                <source>Auto Layout (Columns)</source>
+            </trans-unit>
             <trans-unit id="grid.label.variableWidth" xml:space="preserve">
-				<source>Variable width</source>
-			</trans-unit>
+                <source>Variable Width</source>
+            </trans-unit>
             <trans-unit id="grid.label.rowCustom" xml:space="preserve">
-				<source>Custom row classes</source>
-			</trans-unit>
+                <source>Custom Row Classes</source>
+            </trans-unit>
 
             <trans-unit id="grid.sheet.animation" xml:space="preserve">
-				<source>Animation</source>
-			</trans-unit>
-			<trans-unit id="grid.sheet.controls" xml:space="preserve">
-				<source>Controls</source>
-			</trans-unit>
-			<trans-unit id="grid.sheet.options" xml:space="preserve">
-				<source>Options</source>
-			</trans-unit>
+                <source>Animation</source>
+            </trans-unit>
+            <trans-unit id="grid.sheet.controls" xml:space="preserve">
+                <source>Controls</source>
+            </trans-unit>
+            <trans-unit id="grid.sheet.options" xml:space="preserve">
+                <source>Options</source>
+            </trans-unit>
 
             <trans-unit id="grid.sheet.layout" xml:space="preserve">
-				<source>Layout</source>
-			</trans-unit>
-			<trans-unit id="grid.label.style" xml:space="preserve">
-				<source>Style</source>
-			</trans-unit>
-			<trans-unit id="grid.label.tabStyle" xml:space="preserve">
-				<source>Style</source>
-			</trans-unit>
-			<trans-unit id="grid.label.tabStyle.0" xml:space="preserve">
-				<source>Style 1</source>
-			</trans-unit>
-			<trans-unit id="grid.label.tabStyle.1" xml:space="preserve">
-				<source>Style 2</source>
-			</trans-unit>
-			<trans-unit id="grid.label.tabTitle1" xml:space="preserve">
-				<source>Title 1</source>
-			</trans-unit>
-			<trans-unit id="grid.label.tabTitle2" xml:space="preserve">
-				<source>Title 2</source>
-			</trans-unit>
-			<trans-unit id="grid.label.tabTitle3" xml:space="preserve">
-				<source>Title 3</source>
-			</trans-unit>
-			<trans-unit id="grid.label.tabTitle4" xml:space="preserve">
-				<source>Title 4</source>
-			</trans-unit>
-			<trans-unit id="grid.label.tabTitle5" xml:space="preserve">
-				<source>Title 5</source>
-			</trans-unit>
-			<trans-unit id="grid.label.tabTitle6" xml:space="preserve">
-				<source>Title 6</source>
-			</trans-unit>
-			<trans-unit id="grid.label.tabTitle7" xml:space="preserve">
-				<source>Title 7</source>
-			</trans-unit>
-			<trans-unit id="grid.label.tabTitle8" xml:space="preserve">
-				<source>Title 8</source>
-			</trans-unit>
+                <source>Layout</source>
+            </trans-unit>
+            <trans-unit id="grid.label.style" xml:space="preserve">
+                <source>Style</source>
+            </trans-unit>
+            <trans-unit id="grid.label.tabStyle" xml:space="preserve">
+                <source>Style</source>
+            </trans-unit>
+            <trans-unit id="grid.label.tabStyle.0" xml:space="preserve">
+                <source>Style 1</source>
+            </trans-unit>
+            <trans-unit id="grid.label.tabStyle.1" xml:space="preserve">
+                <source>Style 2</source>
+            </trans-unit>
+            <trans-unit id="grid.label.tabTitle1" xml:space="preserve">
+                <source>Title 1</source>
+            </trans-unit>
+            <trans-unit id="grid.label.tabTitle2" xml:space="preserve">
+                <source>Title 2</source>
+            </trans-unit>
+            <trans-unit id="grid.label.tabTitle3" xml:space="preserve">
+                <source>Title 3</source>
+            </trans-unit>
+            <trans-unit id="grid.label.tabTitle4" xml:space="preserve">
+                <source>Title 4</source>
+            </trans-unit>
+            <trans-unit id="grid.label.tabTitle5" xml:space="preserve">
+                <source>Title 5</source>
+            </trans-unit>
+            <trans-unit id="grid.label.tabTitle6" xml:space="preserve">
+                <source>Title 6</source>
+            </trans-unit>
+            <trans-unit id="grid.label.tabTitle7" xml:space="preserve">
+                <source>Title 7</source>
+            </trans-unit>
+            <trans-unit id="grid.label.tabTitle8" xml:space="preserve">
+                <source>Title 8</source>
+            </trans-unit>
 
             <trans-unit id="grid.sheet.rowClasses" xml:space="preserve">
-				<source>Row classes</source>
-			</trans-unit>
+                <source>Row Classes</source>
+            </trans-unit>
             <trans-unit id="grid.label.rowValign" xml:space="preserve">
-				<source>Vertical alignment</source>
-			</trans-unit>
+                <source>Vertical Alignment</source>
+            </trans-unit>
             <trans-unit id="grid.rowValign.alignItemsStart" xml:space="preserve">
-				<source>Start</source>
-			</trans-unit>
+                <source>Start</source>
+            </trans-unit>
             <trans-unit id="grid.rowValign.alignItemsCenter" xml:space="preserve">
-				<source>Center</source>
-			</trans-unit>
+                <source>Center</source>
+            </trans-unit>
             <trans-unit id="grid.rowValign.alignItemsEnd" xml:space="preserve">
-				<source>End</source>
-			</trans-unit>
+                <source>End</source>
+            </trans-unit>
             <trans-unit id="grid.label.rowHalign" xml:space="preserve">
-				<source>Horiztontal alignment</source>
-			</trans-unit>
+                <source>Horizontal Alignment</source>
+            </trans-unit>
             <trans-unit id="grid.rowHalign.justifyContentStart" xml:space="preserve">
-				<source>Start</source>
-			</trans-unit>
+                <source>Start</source>
+            </trans-unit>
             <trans-unit id="grid.rowHalign.justifyContentCenter" xml:space="preserve">
-				<source>Center</source>
-			</trans-unit>
+                <source>Center</source>
+            </trans-unit>
             <trans-unit id="grid.rowHalign.justifyContentEnd" xml:space="preserve">
-				<source>End</source>
-			</trans-unit>
+                <source>End</source>
+            </trans-unit>
             <trans-unit id="grid.rowHalign.justifyContentAround" xml:space="preserve">
-				<source>Around</source>
-			</trans-unit>
+                <source>Around</source>
+            </trans-unit>
             <trans-unit id="grid.rowHalign.justifyContentBetween" xml:space="preserve">
-				<source>Between</source>
-			</trans-unit>
+                <source>Between</source>
+            </trans-unit>
 
             <trans-unit id="grid.label.none" xml:space="preserve">
-				<source>none</source>
-			</trans-unit>
-			<trans-unit id="grid.label.yes" xml:space="preserve">
-				<source>yes</source>
-			</trans-unit>
-			<trans-unit id="grid.label.no" xml:space="preserve">
-				<source>no</source>
-			</trans-unit>
+                <source>None</source>
+            </trans-unit>
+            <trans-unit id="grid.label.yes" xml:space="preserve">
+                <source>Yes</source>
+            </trans-unit>
+            <trans-unit id="grid.label.no" xml:space="preserve">
+                <source>No</source>
+            </trans-unit>
 
         </body>
     </file>


### PR DESCRIPTION
Some of what I did here

- Did a diff between `locallang_db.xml` and ` de.locallang_db.xlf` to match them as closely as possible to make future diffs easier (converted intermixed tab/space indents to all be space indents, fixed linebraks, etc.)
- Improved English translation to be title capitalization for the short descriptions to be consistent with other extensions.
- Ran the German translation through some AI suggestions multiple times and fix some misspellings and other grammer issuse.